### PR TITLE
Remove redundant architecture directory

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -1,3 +1,0 @@
-# A happy place
-
-This architecture folder is to start working the documentation for tying components together so that...


### PR DESCRIPTION
The information intended for the deleted directory can be found in the Architecture Documents directory